### PR TITLE
Drop public folder before generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ README.html
 
 db.json
 .DS_Store
+debug.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -205,7 +205,7 @@ gulp.task('api', function(callback) {
 // html covertion
 
 gulp.task('generate-public', shell.task([
-  './node_modules/.bin/hexo generate'
+  'rm -rf public/* && ./node_modules/.bin/hexo generate'
 ]));
 
 // launch demo server


### PR DESCRIPTION
We had an issue where hexo wasn't updating a css file during the generate process.